### PR TITLE
Enhancement: Use ergebnis/composer-normalize instead of localheinz/composer-normalize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "localheinz/composer-normalize": "^1.3",
+        "ergebnis/composer-normalize": "^2.0.0",
         "phpstan/phpstan": "^0.11.19",
         "phpstan/phpstan-deprecation-rules": "^0.11.2",
         "phpstan/phpstan-doctrine": "^0.11.6",


### PR DESCRIPTION
This PR

* [x] uses `ergebnis/composer-normalize` instead of `localheinz/composer-normalize`

💁‍♂ For reference, see https://localheinz.com/blog/2019/12/10/from-localheinz-to-ergebnis/.